### PR TITLE
цвет по умолчанию инструмента раскладки

### DIFF
--- a/src/tools/lay_impost.js
+++ b/src/tools/lay_impost.js
@@ -669,6 +669,9 @@ class ToolLayImpost extends ToolElement {
         }
       }
 
+      // цвет по умолчанию
+      add_by_clr(profile.clr);
+
       if (inset_by_x.clr_group.empty() && inset_by_y.clr_group.empty()) {
         add_by_clr(sys.clr_group);
       }


### PR DESCRIPTION
В методе `tool_wnd` модуля `lay_impost.js`, цвет импоста по умолчанию присваивается как у изделия, но при заполнении массива ограничений цвета `_elm_type_clrs` в методе `elm_type_clrs`, цвет по умолчанию не включается в массив и отменятся.