### PR TITLE
проверка нулевой вставки в обработчике удаления строки

### DIFF
--- a/src/editor/editor_dhtmlx.js
+++ b/src/editor/editor_dhtmlx.js
@@ -1468,7 +1468,7 @@ class Editor extends EditorInvisible {
     if(tabular_section == 'inserts'){
       const {project} = this;
       const {obj} = grid.get_cell_field() || {};
-      if(obj && obj._owner._owner == project.ox){
+      if(obj && obj._owner._owner == project.ox && obj.inset.ref !== $p.utils.blank.guid){
         project.ox.params.clear({cnstr: obj.cnstr, inset: obj.inset});
         project.register_change();
       }


### PR DESCRIPTION
В построителе изделия, выделяем створку, добавляем строку доп. вставок, при этом не делаем выбор вставки (строка пустая), и удаляем строку, срабатывает обработчик события при удалении строки. На удаление выбираются все параметры створки, т.к. в обработчик передается нулевая вставка. Если перейти в свойства створки, параметров не будет.