### PR TITLE
вывод дробной части размерных линий

### DIFF
--- a/src/geometry/dimension_line.js
+++ b/src/geometry/dimension_line.js
@@ -274,7 +274,8 @@ class DimensionLine extends paper.Group {
     children.callout2.visible = !this.hide_c2;
     children.scale.visible = !this.hide_line;
 
-    children.text.content = length.toFixed(0);
+    const digits = parseInt((length - Math.round(length)) * 10, 10) != 0 ? 1 : 0;
+    children.text.content =  length.toFixed(digits);
     children.text.rotation = e.subtract(b).angle;
     children.text.justification = align.ref;
 


### PR DESCRIPTION
Актуально при отображении заполнений с раскладкой. Десятая часть в размерах нужна для проверки суммарного размера, например изделие

![image](https://user-images.githubusercontent.com/33495931/46660862-a6f47c80-cbc0-11e8-9243-dc6d95868ac4.png)

если размеры по `y` округлить при помощи метода `toFixed(0)`, просуммировать все значения, будет расхождение по высоте в 2 мм. Появляются вопросы у пользователей. Чем больше кол-во секций у раскладки, тем расхождение может быть больше.

Данный код выводит десятую часть в размерах, там где она есть.