### PR TITLE
создание свойства доступных параметров

### DIFF
--- a/src/modifiers/catalogs/cat_inserts.js
+++ b/src/modifiers/catalogs/cat_inserts.js
@@ -71,6 +71,8 @@ $p.cat.inserts.__define({
               for(const choice of adel) {
                 mf.choice_params.splice(mf.choice_params.indexOf(choice), 1);
               }
+            } else {
+              mf.choice_params = [];
             }
 
             // если параметр не используется в текущей вставке, делаем ячейку readonly

--- a/src/modifiers/documents/doc_calc_order.js
+++ b/src/modifiers/documents/doc_calc_order.js
@@ -808,10 +808,26 @@ $p.DocCalc_order = class DocCalc_order extends $p.DocCalc_order {
       .then((ox) => {
         // если указана строка-генератор, заполняем реквизиты
         if(row_spec instanceof $p.DpBuyers_orderProductionRow) {
+          
+          // добавляем параметр в характеристику, если используется в текущей вставке
+          const prms = new Set();
+          row_spec.inset.used_params.forEach((param) => {
+            !param.is_calculated && prms.add(param);
+          });
+          row_spec.inset.specification.forEach(({nom}) => {
+            if(nom){
+              const {used_params} = nom;
+              used_params && used_params.forEach((param) => {
+                !param.is_calculated && prms.add(param);
+              });
+            }
+          });
 
           if(params) {
             params.find_rows({elm: row_spec.row}, (prow) => {
-              ox.params.add(prow, true).inset = row_spec.inset;
+              if (prms.has(prow.param)) {
+                ox.params.add(prow, true).inset = row_spec.inset;
+              }
             });
           }
 


### PR DESCRIPTION
При попытке изменения значения параметра `Цвет уплотнения` в аксессуарах и услухах, падает на строчке

```
filter.ref && mf.choice_params.push({
```

по причине отсутствия массива `choice_params` в `mf`. С данным изменением работает как надо.
Массив создаю в данном месте, потому что здесь присутствует проверка на его существование.