### PR TITLE
fix #477 не поворачивать, если уместим по ширине

### DIFF
--- a/src/geometry/filling.js
+++ b/src/geometry/filling.js
@@ -301,7 +301,6 @@ class Filling extends AbstractFilling(BuilderElement) {
 
     // Задаем надпись формулы
     const {bounds} = path;
-    let turn = bounds.width * 1.5 < bounds.height;
     _attr._text.content = this.formula();
 
     const textBounds = bounds.scale(0.9);
@@ -309,6 +308,7 @@ class Filling extends AbstractFilling(BuilderElement) {
     textBounds.height = textBounds.height > maxTextWidth ? maxTextWidth : textBounds.height;
 
     if(is_rectangular){
+      const turn = textBounds.width * 1.5 < textBounds.height;
       _attr._text.fitBounds(textBounds);
       _attr._text.point = turn
         ? bounds.bottomRight.add([-fontSize, -fontSize * 0.6])


### PR DESCRIPTION
Необходимость поворота определяем уже после формирования области вписывания.