### PR TITLE
перерисовать контуры, если не было смещений по X

### DIFF
--- a/src/geometry/scheme.js
+++ b/src/geometry/scheme.js
@@ -781,7 +781,14 @@ class Scheme extends paper.Project {
     }
 
     // при необходимости двигаем импосты
-    other.length && Math.abs(delta.x) > 1 && this.do_align(auto_align, profiles);
+    if (other.length && Math.abs(delta.x) > 1) {
+      this.do_align(auto_align, profiles);
+    } else {
+      // иначе перерисовываем контуры
+      setTimeout(() => {
+        this.contours.forEach(l => l.redraw());
+      }, 100);
+    }
 
     _dp._manager.emit_async('update', {}, {x1: true, x2: true, y1: true, y2: true, a1: true, a2: true, cnn1: true, cnn2: true, info: true});
 


### PR DESCRIPTION
После добавления затычки [oknosoft/windowbuilder/commit/42ff8ab45b61d4b981e10ba9954b19173dc53449#diff-34e81e926ff936d7d77048422aa5a854R8816](https://github.com/oknosoft/windowbuilder/commit/42ff8ab45b61d4b981e10ba9954b19173dc53449#diff-34e81e926ff936d7d77048422aa5a854R8816) из темы [607](https://github.com/unpete/ecookna/issues/607) перестали перерисовываться гармошки при изменении высоты со сдвигом вверх или вниз, в частности 431 и 541. Гармошка 321 работает.

Если сдвига по X не произошло, автоуравнивание не применяем, но оно могло произойти по Y, в этом случае нужно перерисовать контуры.