### PR TITLE
Привязка контекста к функции rectification

### DIFF
--- a/src/tools/lay_impost.js
+++ b/src/tools/lay_impost.js
@@ -850,7 +850,7 @@ class ToolLayImpost extends ToolElement {
 
     // уточним направления путей для витража
     if (!this.hitItem) {
-      rectification();
+      rectification.bind(this)();
     }
 
     this.paths.forEach((p) => {


### PR DESCRIPTION
Если создавать изделие с нуля, используя инструмент "Вставить раскладку или импосты", с типом элемента Рама, приводит к ошибке в строке

```
this.paths.forEach((p) => {
```