### PR TITLE
передача атрибутов для пересчета изделия

### DIFF
--- a/src/modifiers/catalogs/cat_characteristics.js
+++ b/src/modifiers/catalogs/cat_characteristics.js
@@ -380,7 +380,7 @@ $p.CatCharacteristics = class CatCharacteristics extends $p.CatCharacteristics {
       .then(() => {
 
         // выполняем пересчет
-        project.save_coordinates({save: true, svg: false});
+        project.save_coordinates(Object.assign({save: true, svg: false}, attr));
 
       })
       .then(() => {


### PR DESCRIPTION
Понадобилось при вызове метода `recalc`, передать `svg: true`, для перерисовки эскиза.