### PR TITLE
исправление записи характеристики в строку текущей вставки

### DIFF
--- a/src/modifiers/documents/doc_calc_order.js
+++ b/src/modifiers/documents/doc_calc_order.js
@@ -914,6 +914,8 @@ $p.DocCalc_order = class DocCalc_order extends $p.DocCalc_order {
             row_spec.inset.calculate_spec({elm, len_angl, ox: row_prod.characteristic});
             // сворачиваем
             row_prod.characteristic.specification.group_by('nom,clr,characteristic,len,width,s,elm,alp1,alp2,origin,dop', 'qty,totqty,totqty1');
+            // помещаем характеристику в строку текущей вставки
+            row_spec.characteristic = row_prod.characteristic;
             return row_prod;
           });
       }


### PR DESCRIPTION
Исправление проблемы порождения лишних строк продукции через диалог `Аксессуары и услуги`. Проявляется если добавить любую вставку и нажимать на кнопку `Рассчитать`, а потом `Рассчитать и закрыть`, в продукции будет несколько одинаковых позиций равные кол-ву нажатий.

В методе `process_add_product_list` модуля `doc_calc_order.js`, в расчете спецификации по текущей вставке, характеристика не записывается в `row_spec`, это ведет к повторному добавлению строки продукции, т.к. при попадании в метод `create_product_row`, характеристика будет не уникальной, а нулевой, следовательно будет создана заново.