### PR TITLE
сохранение атрибутов фильтра списка заказов

### DIFF
--- a/src/components/CalcOrderList/CalcOrderListDhtmlx.js
+++ b/src/components/CalcOrderList/CalcOrderListDhtmlx.js
@@ -9,8 +9,10 @@ class CalcOrderList extends DhtmlxCell {
 
   componentDidMount() {
 
-    let {location, state_filter, handleIfaceState} = this.props;
+    let {location, state_filter, date_from_filter, date_till_filter, filter_filter, handleIfaceState} = this.props;
     const search = $p.job_prm.parse_url_str(location.search);
+    
+    // фильтр по состоянию заказов
     if (search.state_filter && search.state_filter != state_filter) {
       state_filter = search.state_filter;
     }
@@ -19,9 +21,52 @@ class CalcOrderList extends DhtmlxCell {
     }
     set_state_and_title(state_filter, handleIfaceState);
 
+    // фильтр по начальной дате
+    if (search.date_from_filter && search.date_from_filter != date_from_filter) {
+      date_from_filter = search.date_from_filter;
+    }
+    else if (!date_from_filter) {
+      date_from_filter = moment().subtract(2, 'month').toDate().toString();
+    }
+    handleIfaceState({
+      component: 'CalcOrderList',
+      name: 'date_from_filter',
+      value: date_from_filter
+    });
+
+    // фильтр по конечной дате
+    if (search.date_till_filter && search.date_till_filter != date_till_filter) {
+      date_till_filter = search.date_till_filter;
+    }
+    else if (!date_till_filter) {
+      date_till_filter = moment().add(1, 'month').toDate().toString();
+    }
+    handleIfaceState({
+      component: 'CalcOrderList',
+      name: 'date_till_filter',
+      value: date_till_filter
+    });
+
+    // фильтр по поисковой строке
+    if (search.filter_filter && search.filter_filter != filter_filter) {
+      filter_filter = search.filter_filter;
+    }
+    else if (!filter_filter) {
+      filter_filter = '';
+    }
+    handleIfaceState({
+      component: 'CalcOrderList',
+      name: 'filter_filter',
+      value: filter_filter
+    });
+
     super.componentDidMount();
     const {cell, handlers} = this;
-    $p.doc.calc_order.form_list(cell, null, handlers);
+    $p.doc.calc_order.form_list(cell, {
+      date_from: Date.parse(date_from_filter),
+      date_till: Date.parse(date_till_filter),
+      filter: filter_filter
+    }, handlers);
   }
 
   componentWillUnmount() {

--- a/src/modifiers/documents/doc_calc_order_form_list.js
+++ b/src/modifiers/documents/doc_calc_order_form_list.js
@@ -9,19 +9,41 @@
 
 $p.doc.calc_order.form_list = function(pwnd, attr, handlers){
 
-	if(!attr){
-		attr = {
-			hide_header: true,
-			date_from: moment().subtract(2, 'month').toDate(),
-			date_till: moment().add(1, 'month').toDate(),
-			on_new: (o) => {
-        handlers.handleNavigate(`/${this.class_name}/${o.ref}`);
-			},
-			on_edit: (_mgr, ref) => {
-        handlers.handleNavigate(`/${_mgr.class_name}/${ref}`);
-			}
-		};
-	}
+  // сохраняет атрибуты
+  function store_attr(wnd) {
+    const {elmnts} = wnd;
+    const {filter, date_from, date_till} = elmnts.filter.get_filter();
+
+    handlers.handleIfaceState({
+      component: 'CalcOrderList',
+      name: 'date_from_filter',
+      value: date_from.toString()
+    });
+    handlers.handleIfaceState({
+      component: 'CalcOrderList',
+      name: 'date_till_filter',
+      value: date_till.toString()
+    });
+    handlers.handleIfaceState({
+      component: 'CalcOrderList',
+      name: 'filter_filter',
+      value: filter
+    });
+  }
+
+  attr = Object.assign({
+    hide_header: true,
+    date_from: moment().subtract(2, 'month').toDate(),
+    date_till: moment().add(1, 'month').toDate(),
+    on_new: (o) => {
+      store_attr(pwnd);
+      handlers.handleNavigate(`/${this.class_name}/${o.ref}`);
+    },
+    on_edit: (_mgr, ref) => {
+      store_attr(pwnd);
+      handlers.handleNavigate(`/${_mgr.class_name}/${ref}`);
+    }
+  }, attr || {});
 
   return new Promise((resolve, reject) => {
 
@@ -172,6 +194,7 @@ $p.doc.calc_order.form_list = function(pwnd, attr, handlers){
       elmnts.status_bar = wnd.attachStatusBar();
       elmnts.svgs = new $p.iface.OSvgs(wnd, elmnts.status_bar,
         (ref, dbl) => {
+          store_attr(wnd);
           //dbl && $p.iface.set_hash("cat.characteristics", ref, "builder")
           dbl && handlers.handleNavigate(`/builder/${ref}`);
         });
@@ -214,6 +237,7 @@ $p.doc.calc_order.form_list = function(pwnd, attr, handlers){
             const {calc_order} = $p.doc;
             calc_order.clone(ref)
               .then((doc) => {
+                store_attr(wnd);
                 handlers.handleNavigate(`/${calc_order.class_name}/${doc.ref}`);
               })
               .catch($p.record_log);

--- a/src/redux/reducers/iface.js
+++ b/src/redux/reducers/iface.js
@@ -53,6 +53,9 @@ const initialState = {
   },
   CalcOrderList: {
     state_filter: '',
+    filter_filter: '',
+    date_from_filter: '',
+    date_till_filter: ''
   },
   NavDrawer: {
     open: false,


### PR DESCRIPTION
Возникла задача сохранять остальные атрибуты фильтра списка заказов (временной интервал и поисковую строку).

Реализовал по следующей логике, перед уходом с интерфейсной части со списком заказов, например в редактирование изделия, все атрибуты фильтра, кроме подразделения, сохраняются в параметры пользователя. Когда мы возвращаемся, атрибуты подгружаются в интерфейс и обнуляются в параметрах пользователя, для того чтобы не делать кнопки сброса значений атрибутов на по умолчанию, а просто обновиться по F5 и получить значения фильтра по умолчанию.