### PR TITLE
исправление поиска вставки по умолчанию в допах

### DIFF
--- a/src/components/CalcOrderAdditions/AdditionsGroups.js
+++ b/src/components/CalcOrderAdditions/AdditionsGroups.js
@@ -12,7 +12,7 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import AdditionsGroup from './AdditionsGroup';
-import {alasql_schemas, fill_data} from './connect';
+import {alasql_schemas, fill_data, find_inset} from './connect';
 
 
 export default class AdditionsGroups extends React.Component {
@@ -64,7 +64,7 @@ export default class AdditionsGroups extends React.Component {
     return <List>
       {schemas ?
         items.map(group => {
-          if(!group) {
+          if(!group || !find_inset.call({}, group)) {
             return null;
           }
           const cmp = components.get(group);

--- a/src/components/CalcOrderAdditions/connect.js
+++ b/src/components/CalcOrderAdditions/connect.js
@@ -59,7 +59,16 @@ export function fill_data(ref) {
 
 export function find_inset(insert_type) {
   if(!this._inset) {
+    const {branch_filter} = $p.job_prm.builder;
     const inset = $p.cat.inserts.find_rows({available: true, insert_type})
+      .reduce((curr, next) => {
+        if (branch_filter && branch_filter.inset) {
+          branch_filter.inset.indexOf(next.ref) !== -1 && curr.push(next);
+        } else {
+          curr.push(next);
+        }
+        return curr;
+      }, [])
       .reduce((curr, next) => !curr.empty() && curr.priority >= next.priority ? curr : next, $p.cat.inserts.get());
     if (!inset.empty()) {
       this._inset = inset;

--- a/src/components/CalcOrderAdditions/connect.js
+++ b/src/components/CalcOrderAdditions/connect.js
@@ -59,8 +59,11 @@ export function fill_data(ref) {
 
 export function find_inset(insert_type) {
   if(!this._inset) {
-    this._inset = $p.cat.inserts.find_rows({available: true, insert_type})
-      .reduce((curr, next) => curr.priority >= next.priority ? curr : next);
+    const inset = $p.cat.inserts.find_rows({available: true, insert_type})
+      .reduce((curr, next) => !curr.empty() && curr.priority >= next.priority ? curr : next, $p.cat.inserts.get());
+    if (!inset.empty()) {
+      this._inset = inset;
+    }
   }
   return this._inset;
 }


### PR DESCRIPTION
Ошибка в `reduce`, т.к. вторым параметром первоначальное значение не задано, а для пустого массива, его нужно указать. Ловлю у Калевы, т.к. для некоторых типов вставок, вставки отсутствуют и `find_rows` возвращает пустой массив с последующим обрушением `reduce`.