### PR TITLE
исправление синхронизации параметров продукции

### DIFF
--- a/src/components/CalcOrderAdditions/AdditionsGroup.js
+++ b/src/components/CalcOrderAdditions/AdditionsGroup.js
@@ -50,12 +50,19 @@ class AdditionsGroup extends React.Component {
 
   handleRemove = () => {
     const {props, tabular, state} = this;
+    const {dp: {product_params}} = props;
     if(tabular){
       const {selected} = tabular._grid.state;
       const row = tabular.rowGetter(selected && selected.hasOwnProperty('rowIdx') ? selected.rowIdx : 0);
       if(row){
         const {calc_order_row} = row.characteristic;
         row._owner.del(row);
+        product_params.clear({elm: row.row});
+        product_params.forEach(param => {
+          if (param.elm > row.row) {
+            param.elm--;
+          }
+        });
         tabular.forceUpdate();
         if(state.count) {
           this.setState({

--- a/src/metadata/dataprocessors/dp_buyers_order.js
+++ b/src/metadata/dataprocessors/dp_buyers_order.js
@@ -98,6 +98,11 @@ export default function ($p) {
           const {product_params} = _owner._owner;
           const defaults = this.inset.product_params;
           product_params.clear({elm: row});
+          product_params.forEach(param => {
+            if (param.elm > row) {
+              param.elm--;
+            }
+          });
           this.inset.used_params.forEach((param) => {
             const prow = product_params.add({elm: row, param: param});
 


### PR DESCRIPTION
Проблема с параметрами в аксессуарах и услугах. Как повторить, добавляем, например вставки подоконников в той последовательности как на скриншоте

![image](https://user-images.githubusercontent.com/33495931/53560706-0c400e80-3b5e-11e9-8caf-301d675c6095.png)

выделяем, например третью позицию и жмем удалить, строка удаляется, но в параметрах происходит рассинхронизация, как на скриншоте

![image](https://user-images.githubusercontent.com/33495931/53560874-6ccf4b80-3b5e-11e9-9523-d656bfe614d1.png)

Элементы массива с параметрами связаны со строками списка через поле `elm`, его необходимо корректировать, чтобы параметр соответствовал выбранной вставке.