### PR TITLE
исправление скрытия параметров в refresh_prm_links()

### DIFF
--- a/src/geometry/contour.js
+++ b/src/geometry/contour.js
@@ -1844,7 +1844,7 @@ class Contour extends AbstractFilling(paper.Layer) {
       const {param} = prow;
       const links = param.params_links({grid: {selection: {cnstr}}, obj: prow});
       // вычисляемые скрываем всегда
-      let hide = param.is_calculated;
+      let hide = param.is_calculated && !param.show_calculated;
       // если для параметра есть связи - сокрытие по связям
       if(!hide){
         if(links.length) {


### PR DESCRIPTION
Есть вычисляемые параметры, которые необходимо отображать, про них совсем забыли и не проверили. Поймали на водоотливах, параметр `Длина`.