### PR TITLE
размер соединения в припуске по умолчанию

### DIFF
--- a/src/geometry/profile.js
+++ b/src/geometry/profile.js
@@ -731,7 +731,7 @@ class ProfileItem extends GeneratrixElement {
   get dx0() {
     const {cnn} = this.rays.b;
     const main_row = cnn && cnn.main_row(this);
-    return main_row && main_row.angle_calc_method == $p.enm.angle_calculating_ways.СварнойШов ? -main_row.sz : 0;
+    return main_row && main_row.angle_calc_method == $p.enm.angle_calculating_ways.СварнойШов ? -main_row.sz : cnn.sz;
   }
 
   setSelection(selection) {


### PR DESCRIPTION
Решение предлагаю, как альтернативу отключенному модификатору подмены метода получения спецификации фурнитуры. Данная доработка актуальна в изделиях с импостами на которых раполагаются обработки. Суть проблемы, если рассмотреть горизонтальный импост, то по оси OX его начало идет не от нуля, а со смещением. Это смещение, наши технологи, задают в размере соединения. При получении спецификации фурнитуры, если в операциях фурнитуры есть отметка припуск, но у соединения не указан расчет угла `Сварной шов`, припуск задается как размер соединения, а не ноль, как сейчас по умолчанию.

Если данное решение не использовать на уровне ядра системы, прийдется учитывать во всех формулах для технолога, по сути множить логику и проверки.

Если не понятно и нужен пример, сообщите.