### PR TITLE
исправление перемещения произвольного текста

### DIFF
--- a/src/geometry/freetext.js
+++ b/src/geometry/freetext.js
@@ -110,9 +110,7 @@ class FreeText extends paper.PointText {
       font_family: this.font_family,
       font_size: this.font_size,
       bold: this.bold,
-      align: this.align.ref,
-      bounds_x: this.project.bounds.x,
-      bounds_y: this.project.bounds.y
+      align: this.align.ref
     });
   }
 


### PR DESCRIPTION
Ошибку наблюдаем, например в отливах, когда размещаем на эскизе произвольную надпись. Если заходить в редактор изделия и выходить с сохранением, получаем смещение (движение) произвольного текста равное значениям величин полей `bound_x` и `bound_y`. В конструкторе класса `FreeText`, задается позиция надписи как `x` + `bound_x`, если был задан `path_data` и в рамках новых границ мы получаем неверное смещение, такой же эффект с `y`.