### PR TITLE
исправление порчи спецификации для сэндвичей

### DIFF
--- a/src/geometry/filling.js
+++ b/src/geometry/filling.js
@@ -389,7 +389,7 @@ class Filling extends AbstractFilling(BuilderElement) {
       // если для заполнение определён состав - корректируем
       if(proto.length) {
         glass_specification.clear({elm});
-        proto.length = 0;
+        /*proto.length = 0;
         inset.specification.forEach((row) => {
           if(row.nom instanceof $p.CatInserts){
             proto.push(glass_specification.add({
@@ -398,7 +398,7 @@ class Filling extends AbstractFilling(BuilderElement) {
               clr: row.clr,
             }))
           }
-        });
+        });*/
       }
 
       // транслируем изменения на остальные выделенные заполнения
@@ -408,11 +408,11 @@ class Filling extends AbstractFilling(BuilderElement) {
           selm.set_inset(inset, true);
           // копируем состав заполнения
           glass_specification.clear({elm: selm.elm});
-          proto.forEach((row) => glass_specification.add({
+          /*proto.forEach((row) => glass_specification.add({
             elm: selm.elm,
             inset: row.inset,
             clr: row.clr,
-          }));
+          }));*/
         }
       });
     }


### PR DESCRIPTION
Как воспроизвести, для заполнения заходим в `Состав заполнения в элемент`, заполняем из существующей вставки, выходим и меняем вставку со стеклопакета на любой сэндвич. В результате в составе заполнения в элемент получаем часть строк из сэндвича и следовательно неверно рассчитанную спецификацию.

Так и не смог понять зачем при смене вставки, заполнять элементами спецификации этой вставки еще и состав заполнения в элемент. Если вставку сменили, то состав нужно просто очистить.