### PR TITLE
список фурнитуры для каждого контура в refill_prm

### DIFF
--- a/src/modifiers/catalogs/cat_production_params.js
+++ b/src/modifiers/catalogs/cat_production_params.js
@@ -64,13 +64,13 @@ $p.CatProduction_params.prototype.__define({
    * @for Production_params
    */
   furns: {
-    value(ox){
+    value(ox, cnstr = 0){
       const {furn} = $p.job_prm.properties;
       const {furns} = $p.cat;
       const list = [];
       if(furn){
         const links = furn.params_links({
-          grid: {selection: {cnstr: 0}},
+          grid: {selection: {cnstr}},
           obj: {_owner: {_owner: ox}}
         });
         if(links.length){
@@ -201,13 +201,12 @@ $p.CatProduction_params.prototype.__define({
 				ox.owner = ox.prod_nom;
 
 				// если текущая фурнитура недоступна для данной системы - меняем
-        const furns = this.furns(ox);
-
 				// одновременно, перезаполним параметры фурнитуры
 				ox.constructions.forEach((row) => {
           if(!row.furn.empty()) {
-            let changed = force;
-            // если для системы через связи параметров ограничен список фурнитуры...
+						let changed = force;
+						// если для системы через связи параметров ограничен список фурнитуры...
+						const furns = this.furns(ox, row.cnstr);
             if(furns.length) {
               if(furns.some((frow) => {
                 if(frow.forcibly) {


### PR DESCRIPTION
Проблема заключается в изменении фурнитуры створок при копировании изделия. Список фурнитуры необходимо получать для каждого контура, т.к. в зависимости от конфигурации створок список фурнитур может отличаться. У нас, на список фурнитуры влияют связи в которых используются ключи с вычисляемым параметром `Признак Прямоугольности Контура`, т.к. одна створка может быть прямоугольной, а другая нет, или створки прямоугольные, а изделие нет, это приведет к формированию списка фурнитуры для, например, не прямоугольного изделия, хотя створки таковыми не являются и сформированный список фурнитуры им не подойдет.

Для примера в dev есть счет `00-007-0008`, в нем 4 позиция продукции, ее попробовать скопировать.