### PR TITLE
создание обратного составного цвета

### DIFF
--- a/src/modifiers/catalogs/cat_clrs.js
+++ b/src/modifiers/catalogs/cat_clrs.js
@@ -173,30 +173,31 @@ $p.cat.clrs.__define({
             pwnd.on_select.call(pwnd, eclr.clr_in);
           }
           else {
-            // ищем в справочнике цветов
-            const ares = $p.wsql.alasql("select top 1 ref from cat_clrs where clr_in = ? and clr_out = ? and (not ref = ?)",
-              [eclr.clr_in.ref, eclr.clr_out.ref, $p.utils.blank.guid]);
+            // дополнительно проверяем обратный цвет
+            const clrs = [eclr, {clr_in: eclr.clr_out, clr_out: eclr.clr_in}]
+              .map(({clr_in, clr_out}) => {
+                // ищем в справочнике цветов
+                const ares = $p.wsql.alasql("select top 1 ref from cat_clrs where clr_in = ? and clr_out = ? and (not ref = ?)",
+                  [clr_in.ref, clr_out.ref, $p.utils.blank.guid]);
+                
+                // если не нашли - создаём
+                return ares.length ? Promise.resolve($p.cat.clrs.get(ares[0])) : $p.cat.clrs.create({
+                  clr_in,
+                  clr_out,
+                  name: `${clr_in.name} \\ ${clr_out.name}`,
+                  parent: $p.job_prm.builder.composite_clr_folder
+                })
+                  // регистрируем цвет в couchdb
+                  .then((obj) => obj.register_on_server());
+              });
 
-            // если не нашли - создаём
-            if(ares.length){
-              pwnd.on_select.call(pwnd, $p.cat.clrs.get(ares[0]));
-            }
-            else{
-              $p.cat.clrs.create({
-                clr_in: eclr.clr_in,
-                clr_out: eclr.clr_out,
-                name: `${eclr.clr_in.name} \\ ${eclr.clr_out.name}`,
-                parent: $p.job_prm.builder.composite_clr_folder
-              })
-              // регистрируем цвет в couchdb
-                .then((obj) => obj.register_on_server())
-                .then((obj) => pwnd.on_select.call(pwnd, obj))
-                .catch((err) => $p.msg.show_msg({
-                  type: 'alert-warning',
-                  text: 'Недостаточно прав для добавления составного цвета',
-                  title: 'Составной цвет'
-                }));
-            }
+            Promise.all(clrs)
+              .then(objs => pwnd.on_select.call(pwnd, objs[0]))
+              .catch((err) => $p.msg.show_msg({
+                type: 'alert-warning',
+                text: 'Недостаточно прав для добавления составного цвета',
+                title: 'Составной цвет'
+              }));
           }
 
           wnd.close();


### PR DESCRIPTION
После создания составного цвета, в некоторых изделиях, там где есть вставки, в которых выписывается номенклатура с цветом `КакЭлементИнверсный`, получаем строки спецификации с цветом не обратным, т.к. обратного цвета пока не существует и метод `this.inverted(clr_elm);` возвращает цвет, который в него был передан. В данном решении при создании составного цвета еще создается обратный.