### PR TITLE
копирование спецификации стеклопакета из прототипа

### DIFF
--- a/src/geometry/element.js
+++ b/src/geometry/element.js
@@ -42,6 +42,10 @@ class BuilderElement extends paper.Group {
 
     this._attr = {};
 
+    if(!this._row.elm){
+      this._row.elm = this.project.ox.coordinates.aggregate([], ["elm"], "max") + 1;
+    }
+
     if(attr.proto){
 
       if(attr.proto.inset){
@@ -68,10 +72,6 @@ class BuilderElement extends paper.Group {
 
     if(!this._row.cnstr && this.layer.cnstr){
       this._row.cnstr = this.layer.cnstr;
-    }
-
-    if(!this._row.elm){
-      this._row.elm = this.project.ox.coordinates.aggregate([], ["elm"], "max") + 1;
     }
 
     if(this._row.elm_type.empty() && !this.inset.empty()){

--- a/src/geometry/filling.js
+++ b/src/geometry/filling.js
@@ -104,6 +104,20 @@ class Filling extends AbstractFilling(BuilderElement) {
       elm_type: $p.enm.elm_types.Раскладка
     }, (row) => new Onlay({row: row, parent: this}));
 
+    // спецификация стеклопакета прототипа
+    if (attr.proto) {
+      const tmp = [];
+      project.ox.glass_specification.find_rows({elm: attr.proto.elm}, (row) => {
+        tmp.push({
+          clr: row.clr,
+          elm: this.elm,
+          gno: row.gno,
+          inset: row.inset
+        });
+      });
+      tmp.forEach(row => project.ox.glass_specification.add(row));
+    }
+
   }
 
   /**


### PR DESCRIPTION
При делении контура импостом, в новое заполнение не попадает спецификация стеклопакета, введенная через состав заполнения у прототипа.

В конструкторе класса `BuilderElement`, переместил строки присвоения нового номера элемента чуть выше, т.к. при создании элемента из прототипа, назначается вставка через метод `set_inset`, в котором имеется очистка `glass_specification.clear({elm});`, элемент в фильтре всегда равен 0, а должен быть номер создаваемого элемента. 

```
if(!this._row.elm){
  this._row.elm = this.project.ox.coordinates.aggregate([], ["elm"], "max") + 1;
}
```