### PR TITLE
очистка незаполненных строк состава заполнения

### DIFF
--- a/src/editor/glass_inserts.js
+++ b/src/editor/glass_inserts.js
@@ -54,12 +54,15 @@ class GlassInserts {
   onclose() {
     const {grids} = this.wnd.elmnts;
     const {elm, glasses} = this;
+    const {glass_specification} = elm.project.ox;
     grids.inserts && grids.inserts.editStop();
+
+    // очищаем незаполненные строки табличной части
+    glass_specification.clear({elm: elm.elm, inset: $p.utils.blank.guid});
 
     // распространим изменения на все выделенные заполнения
     for(let i = 1; i < glasses.length; i++) {
       const selm = glasses[i];
-      const {glass_specification} = elm.project.ox;
       glass_specification.clear({elm: selm.elm});
       glass_specification.find_rows({elm: elm.elm}, (row) => {
         glass_specification.add({

--- a/src/geometry/filling.js
+++ b/src/geometry/filling.js
@@ -433,6 +433,9 @@ class Filling extends AbstractFilling(BuilderElement) {
   formula(by_art) {
     let res;
     this.project.ox.glass_specification.find_rows({elm: this.elm}, (row) => {
+      if(row.inset.empty()){
+        return;
+      }
       let {name, article} = row.inset;
       const aname = row.inset.name.split(' ');
       if(by_art && article){

--- a/src/modifiers/catalogs/cat_inserts.js
+++ b/src/modifiers/catalogs/cat_inserts.js
@@ -467,7 +467,9 @@ $p.CatInserts = class CatInserts extends $p.CatInserts {
 
       const glass_rows = [];
       ox.glass_specification.find_rows({elm: elm.elm}, (row) => {
-        glass_rows.push(row);
+        if(!row.inset.empty()){
+          glass_rows.push(row);
+        }
       });
 
       // если спецификация верхнего уровня задана в изделии, используем её, параллельно формируем формулу


### PR DESCRIPTION
Случаются ошибки отсутствия стеклопакета в изделии по причине пустой строки в составе заполнения. Менеджер после редактирования состава заполнения оставляет пустую строку, у которой не выбрана вставка, в результате в спецификацию стеклопакет не выписывается.