### PR TITLE
сохраняем характеристику после пересчета цен

### DIFF
--- a/src/modifiers/documents/doc_calc_order.js
+++ b/src/modifiers/documents/doc_calc_order.js
@@ -1019,10 +1019,9 @@ $p.DocCalc_order = class DocCalc_order extends $p.DocCalc_order {
               const elm = new $p.DocCalc_order.FakeElm(row);
               characteristic.origin.calculate_spec({elm, len_angl, ox: characteristic});
               tmp = tmp.then(() => {
-                return characteristic.save().then(() => {
-                  // выполняем пересчет
-                  row.value_change('quantity', '', row.quantity);
-                });
+                // выполняем пересчет
+                row.value_change('quantity', '', row.quantity);
+                return characteristic.save();
               });
             }
             else {


### PR DESCRIPTION
Как воспроизвести, добавить в заказ параметрическое изделие, нажать на кнопку `Пересчитать заказ`, сохранить заказ, обновиться, в спецификации параметрического изделия цены будут отсутствовать.