### PR TITLE
ведущая продукция

### DIFF
--- a/src/modifiers/catalogs/cat_characteristics.js
+++ b/src/modifiers/catalogs/cat_characteristics.js
@@ -143,7 +143,7 @@ $p.CatCharacteristics = class CatCharacteristics extends $p.CatCharacteristics {
       name += '/' + calc_order_row.row.pad();
 
       // для подчиненных, номер строки родителя
-      if(!leading_product.empty()) {
+      if(!leading_product.empty() && leading_product.calc_order_row) {
         name += ':' + leading_product.calc_order_row.row.pad();
       }
 

--- a/src/modifiers/documents/doc_calc_order.js
+++ b/src/modifiers/documents/doc_calc_order.js
@@ -335,6 +335,25 @@ $p.DocCalc_order = class DocCalc_order extends $p.DocCalc_order {
 
   }
 
+  // удаление строки
+  del_row(row) {
+    // запрет удаления подчиненной продукции
+    if(!row.characteristic.empty()) {
+      const {msg} = $p;
+      const {leading_elm, leading_product, name} = row.characteristic;
+      if(leading_elm !== 0 && !leading_product.empty() && leading_product.calc_order_row) {
+        msg.show_msg && msg.show_msg({
+          type: 'alert-warning',
+          text: `Изделие не может быть удалено. Для удаления, пройдите в ${leading_product.name} и отредактируйте доп. вставки.`,
+          title: this.presentation
+        });
+        return false;
+      }
+    }
+
+    return this;
+  }
+
   // при удалении строки
   after_del_row(name) {
     name === 'production' && this.product_rows();


### PR DESCRIPTION
По первому коммиту. Ошибка происходит когда ведущую продукцию удаляют из заказа, а подчинённая остаётся. Такую продукцию уже пересчитать нельзя, т.к. ссылка на объект характеристики в `leading_product` становится битой, но в ней остаётся заполненным только `ref`. Это приводит к `empty() == false` и обращению к `leading_product.calc_order_row`, который уже `undefined`, что приводит к падению на `leading_product.calc_order_row.row`.

По второму коммиту. Доработка понадобилась чтобы предотвратить удаление подчинённой продукции, если в заказе имеется ведущая. Периодически обращаются с формулировкой - Почему на эскизе изделия имеется антимоскитная сетка, а клиенту её не изготовили? Объясняем, что при добавлении через доп. вставку должна быть еще строка продукции с антимоскитной сеткой. Смотрим историю заказа, оказывается сетку просто удалили, а в ведущем изделии из доп. вставок нет.

Эти решения допускают удаление ведущей продукции с возможностью оставить подчинённые. Это конечно не правильно, с потерей ведущего изделия, подчинённая теряет возможность пересчитываться, т.к. не принадлежит вставке и изделию. Продолжением этих решений может стать удаление подчинённых продукций вместе с ведущей или преобразование подчинённой продукции в параметрическую.

Простите, опять делаю предложение решения в надежде быть отвергнутым.