### PR TITLE
исправление изменение вставки элементов

### DIFF
--- a/src/geometry/profile.js
+++ b/src/geometry/profile.js
@@ -1357,6 +1357,7 @@ class ProfileItem extends GeneratrixElement {
       if(_attr && _attr._rays) {
 
         _attr._rays.clear(true);
+        delete _attr.d0;
 
         // прибиваем соединения в точках b и e
         const b = this.cnn_point('b');


### PR DESCRIPTION
Когда мы меняем вставку, делается пересчёт профиля, у которого меняем, и у примыкающих элементов. На последнем шаге вызывается оповещение об изменении `project.register_change()`, где происходит удаление `d0`, но это необходимо сделать также при смене вставки, чтобы пересчёт профиля прошёл правильно, с новым размером примыкающего соединения, т.к. сейчас используется старое (предыдущее) и расстояние от узла до опорной линии применяется неверное.