### PR TITLE
расчёт радиуса дуги через усреднённое значение

### DIFF
--- a/src/geometry/paper_ex.js
+++ b/src/geometry/paper_ex.js
@@ -409,6 +409,26 @@ Object.defineProperties(paper.Path.prototype, {
     }
   },
 
+  /**
+   * ### Усреднённый радиус, высисляемый по кривизне пути
+   * для прямых = 0
+   */
+  raverage: {
+    value() {
+      if(!this.hasHandles()){
+        return 0;
+      }
+      const {length} = this;
+      const step = length / 50;
+      let sum = 0, count = 0;
+      for(let pos = 0; pos < length; pos += step){
+        sum += Math.abs(this.getCurvatureAt(pos));
+        count++;
+      }
+      return sum === 0 ? 0 : 1 / (sum / count);
+    }
+  },
+
 });
 
 

--- a/src/geometry/profile.js
+++ b/src/geometry/profile.js
@@ -999,11 +999,11 @@ class ProfileItem extends GeneratrixElement {
     _row.nom = this.nom;
 
     // радиус, как дань традиции
-    const rmin = generatrix.rmin();
-    if(rmin) {
+    const raverage = generatrix.raverage();
+    if(raverage) {
       // записываем среднее значение, дельту не анализируем
       // если овал или несколько перегибов, мы это увидим в path_data
-      _row.r = ((rmin + generatrix.rmax()) / 2).round();
+      _row.r = raverage.round();
     }
     else {
       _row.r = 0;


### PR DESCRIPTION
Расчёт радиуса дуги через среднее значение минимального и максимального радиуса даёт существенную погрешность, предлагаю рассчитывать через усреднённое значение радиусов вычисляемых по кривизне дуги с заданным шагом. Экспериментируя, я остановился на шаге, который вычисляется как длина дуги поделенная на 50, в этом случае разница между радиусами дуг створок не превышает нескольких миллиметров (хотя проводил тестирование на одном изделии). Чем делитель больше, тем больше точность вычисляемого радиуса.