### PR TITLE
отрисовка визуализации для фрагмента

### DIFF
--- a/src/geometry/contour.js
+++ b/src/geometry/contour.js
@@ -1561,7 +1561,7 @@ class Contour extends AbstractFilling(paper.Layer) {
   /**
    * Рисует дополнительную визуализацию. Данные берёт из спецификации и проблемных соединений
    */
-  draw_visualization(rows) {
+  draw_visualization(rows, nested = true) {
 
     const {profiles, l_visualization, contours} = this;
     const glasses = this.glasses(false, true);
@@ -1606,8 +1606,10 @@ class Contour extends AbstractFilling(paper.Layer) {
     }
 
     // перерисовываем вложенные контуры
-    for(const contour of contours){
-      contour.draw_visualization(rows);
+    if(nested){
+      for(const contour of contours){
+        contour.draw_visualization(rows);
+      }
     }
 
   }

--- a/src/geometry/scheme.js
+++ b/src/geometry/scheme.js
@@ -634,7 +634,7 @@ class Scheme extends paper.Project {
           l.l_dimensions.redraw(true);
           l.zoom_fit();
           // визуализация для текущего контура
-          /*attr.visualization &&*/ l.draw_visualization();
+          /*attr.visualization &&*/ l.draw_visualization(false, false);
           return true;
         }
       });


### PR DESCRIPTION
Продолжение темы с вензелями у раскладки. 1С:УПП получает данные с сервиса эскизов, которой разбирает изделие на фрагменты и отрисовывает эскизы. Так вот на этих фрагментах нет визуализации, которая в свою очередь очень нужна производству, чтобы знать куда крепить вензеля.

Тема сейчас очень горячая, в компании чуть ли не до скандала дошло, прошу рассмотреть решение.