### PR TITLE
исправл. восстановления соединений с заполнением

### DIFF
--- a/src/editor/editor_dhtmlx.js
+++ b/src/editor/editor_dhtmlx.js
@@ -1300,8 +1300,9 @@ class Editor extends EditorInvisible {
         }
 
         let intersections = glass.path.getIntersections(impost.generatrix);
-        if(intersections.length) {
-          impost[node] = intersections[0].point;
+        let intersection = impost.get_nearest_intersection(intersections, node);
+        if(intersection) {
+          impost[node] = intersection.point;
           restored = true;
         }
         else {
@@ -1320,8 +1321,9 @@ class Editor extends EditorInvisible {
             insert: false,
           });
           intersections = glass.path.getIntersections(line);
-          if(intersections.length) {
-            impost[node] = intersections[0].point;
+          intersection = impost.get_nearest_intersection(intersections, node);
+          if(intersection) {
+            impost[node] = intersection.point;
             restored = true;
           }
         }

--- a/src/geometry/profile_onlay.js
+++ b/src/geometry/profile_onlay.js
@@ -121,6 +121,24 @@ class Onlay extends ProfileItem {
   }
 
   /**
+   * Получение ближайшего пересечения для узла импоста с учётом противоположного узла
+   * @method save_coordinates
+   * @for Onlay
+   */
+  get_nearest_intersection(intersections, node) {
+    let res;
+    const opposite = node === 'b' ? 'e' : 'b';
+    for(let intersection of intersections) {
+      const distance = intersection.point.getDistance(this[node]);
+      const dist_opp = intersection.point.getDistance(this[opposite]);
+      if(distance < dist_opp || (this.rays[opposite].cnn && dist_opp > 1)) {
+        res = intersection;
+      }
+    }
+    return res;
+  }
+
+  /**
    * Вычисляемые поля в таблице координат
    * @method save_coordinates
    * @for Onlay


### PR DESCRIPTION
Тестировал восстановление соединений только для типа деления `Крест в стык`, про деление горизонтальных и вертикальных совсем забыл. Например если выбрать раскладку `Раскладка Varsavia 18мм`, для неё деление горизонтальных, вертикальные импосты имеют соединение снизу и сверху, для такого деления всё ломается.