### PR TITLE
feat: enable proxy setup via .env.PROXY

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -100,7 +100,7 @@ checkBrowsers(paths.appPath, isInteractive)
       webpack,
     });
     // Load proxy config
-    const proxySetting = require(paths.appPackageJson).proxy;
+    const proxySetting = process.env.PROXY || require(paths.appPackageJson).proxy;
     const proxyConfig = prepareProxy(
       proxySetting,
       paths.appPublic,


### PR DESCRIPTION
Позволяет стартовать wb с адресом прокси не из package.json, а из окружения. Например `node --env some.env scripts/start.js`, при этом `some.env` должен содержать ключ типа `PROXY=http://some.domain:3016/`